### PR TITLE
Stop orbit coasting and harden scene interaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+*.tsbuildinfo
 dist
 dist-ssr
 dev-dist

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,18 +1,12 @@
 echo "🔍 Running type check before push..."
-pnpm format
-
-if [ $? -ne 0 ]; then
-    echo "❌ Formatting failed! Please fix the errors before pushing."
-    exit 1
-fi
-
 pnpm lint
+
 if [ $? -ne 0 ]; then
     echo "❌ Linting failed! Please fix the errors before pushing."
     exit 1
 fi
 
-pnpm tsc
+pnpm typecheck
 if [ $? -ne 0 ]; then
     echo "❌ Type check failed! Please fix the errors before pushing."
     exit 1

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "postbuild": "node scripts/create-route-entries.mjs && tsx scripts/generate-dataset.ts && node scripts/generate-sitemap.mjs",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit",
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "format": "biome format --write",
@@ -17,7 +18,7 @@
   "lint-staged": {
     "src/**/*.{ts,tsx,js,jsx}": [
       "biome format --write",
-      "biome check --apply"
+      "biome check --write"
     ],
     "*.{json,md}": [
       "biome format --write"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,6 @@ function HomePage() {
   const [isLoading, setIsLoading] = useState(true)
   const [hasInteracted, setHasInteracted] = useState(false)
   const [isTitleVisible, setIsTitleVisible] = useState(true)
-  const [showLoadingUI, _setShowLoadingUI] = useState(true)
 
   return (
     <>
@@ -32,7 +31,7 @@ function HomePage() {
       <LoadingScreen
         progress={loadingProgress}
         isLoading={isLoading}
-        showLoadingUI={showLoadingUI}
+        showLoadingUI={true}
       />
       <SeoContent />
     </>

--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -30,7 +30,10 @@ import { About } from "./ui/components/About"
 import { ActionButtons } from "./ui/components/ActionButtons"
 import { ActionMenu } from "./ui/components/ActionMenu"
 import { BraveDisclaimer } from "./ui/components/BraveDisclaimer"
-import { HoverTooltip } from "./ui/components/HoverTooltip"
+import {
+  HoverTooltip,
+  type HoverTooltipHandle,
+} from "./ui/components/HoverTooltip"
 import { ResetInstruction } from "./ui/components/ResetInstruction"
 // UI Components
 import { DeityPanel } from "./ui/DeityPanel"
@@ -72,11 +75,6 @@ function PiacenzaLiverScene({
   )
   const [isSceneReady, setIsSceneReady] = useState(false)
   const [isIntroTransitioning, setIsIntroTransitioning] = useState(false)
-  const [immediateMousePosition, setImmediateMousePosition] = useState({
-    x: 0,
-    y: 0,
-    isOverCanvas: true,
-  })
   const [isMouseOverPanel, setIsMouseOverPanel] = useState(false)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const [viewportKey, setViewportKey] = useState(0)
@@ -103,6 +101,7 @@ function PiacenzaLiverScene({
   const cameraControllerRef = useRef<CameraController | null>(null)
   const liverModelRef = useRef<LiverModel | null>(null)
   const interactionManagerRef = useRef<InteractionManager | null>(null)
+  const hoverTooltipRef = useRef<HoverTooltipHandle | null>(null)
 
   // Animation frame ref
   const animationIdRef = useRef<number | null>(null)
@@ -519,20 +518,11 @@ function PiacenzaLiverScene({
     setHasViewChanged(true)
   }, [hasInteracted, setHasInteracted, interactionMode])
 
-  // Mouse move handler with throttling to match raycast timing
-  const mouseMoveTimeoutRef = useRef<number | null>(null)
+  // Keep tooltip position on the DOM — avoid re-rendering the scene tree
+  // on every mousemove.
   const handleMouseMove = useCallback(
     (position: { x: number; y: number }, isOverCanvas: boolean) => {
-      // Clear existing timeout
-      if (mouseMoveTimeoutRef.current) {
-        clearTimeout(mouseMoveTimeoutRef.current)
-      }
-
-      // Throttle updates
-      mouseMoveTimeoutRef.current = window.setTimeout(() => {
-        setImmediateMousePosition({ ...position, isOverCanvas })
-        mouseMoveTimeoutRef.current = null
-      }, SceneConfig.performance.raycastThrottleMs)
+      hoverTooltipRef.current?.setPointer(position.x, position.y, isOverCanvas)
     },
     [],
   )
@@ -909,12 +899,6 @@ function PiacenzaLiverScene({
         handleContextRestore,
       )
 
-      // Clear mouse move timeout
-      if (mouseMoveTimeoutRef.current) {
-        clearTimeout(mouseMoveTimeoutRef.current)
-        mouseMoveTimeoutRef.current = null
-      }
-
       cameraController?.dispose()
       liverModelRef.current?.dispose()
       interactionManagerRef.current?.dispose()
@@ -1178,8 +1162,8 @@ function PiacenzaLiverScene({
         </section>
 
         <HoverTooltip
+          ref={hoverTooltipRef}
           hoveredSection={hoveredSection}
-          mousePosition={immediateMousePosition}
           isPanelOpen={isInscriptionMode}
           isModifierKeyPressed={isModifierKeyPressed}
           isMouseOverPanel={isMouseOverPanel}

--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -70,7 +70,6 @@ function PiacenzaLiverScene({
   const [hoveredSection, setHoveredSection] = useState<HoveredSection | null>(
     null,
   )
-  const [isInteracting, setIsInteracting] = useState(false)
   const [isSceneReady, setIsSceneReady] = useState(false)
   const [isIntroTransitioning, setIsIntroTransitioning] = useState(false)
   const [immediateMousePosition, setImmediateMousePosition] = useState({
@@ -107,17 +106,15 @@ function PiacenzaLiverScene({
 
   // Animation frame ref
   const animationIdRef = useRef<number | null>(null)
-
-  // Timeout refs to prevent panel re-opening after reset
-  const panelTimeoutRef = useRef<number | null>(null)
+  const renderRequestedRef = useRef(true)
 
   // Click debouncing to prevent rapid clicks
   const lastClickTimeRef = useRef<number>(0)
   const clickDebounceDelay = 300 // 300ms debounce
-  const introTimeoutRef = useRef<number | null>(null)
   const initialAnimationTriggeredRef = useRef<boolean>(false)
   const initialCameraDistanceRef = useRef<number | null>(null)
   const initialCameraTargetRef = useRef<THREE.Vector3 | null>(null)
+  const hashNavigationTimeoutRef = useRef<number | null>(null)
 
   const getIntroPose = useCallback(() => {
     const aspect = window.innerWidth / window.innerHeight
@@ -190,13 +187,6 @@ function PiacenzaLiverScene({
       }
 
       setHoveredSection(section)
-      if (liverModelRef.current) {
-        if (section?.id) {
-          liverModelRef.current.setHoveredInscription(section.id)
-        } else {
-          liverModelRef.current.setHoveredInscription(0)
-        }
-      }
     },
     [interactionMode],
   )
@@ -262,16 +252,6 @@ function PiacenzaLiverScene({
   const handleReset = useCallback(() => {
     if (!cameraControllerRef.current) return
 
-    // Clear any pending panel timeout to prevent re-opening after reset
-    if (panelTimeoutRef.current) {
-      clearTimeout(panelTimeoutRef.current)
-      panelTimeoutRef.current = null
-    }
-    if (introTimeoutRef.current) {
-      clearTimeout(introTimeoutRef.current)
-      introTimeoutRef.current = null
-    }
-
     if (interactionManagerRef.current) {
       interactionManagerRef.current.setIntroAnimationMode(true)
     }
@@ -294,7 +274,6 @@ function PiacenzaLiverScene({
     setSelectedInscription(null)
     setInteractionMode(InteractionMode.ThreeD)
     setTitleVisible(true)
-    setIsInteracting(false)
     setHasViewChanged(false)
     clearInscriptionHash()
     if (interactionManagerRef.current) {
@@ -305,17 +284,11 @@ function PiacenzaLiverScene({
   const handleReturnToIntro = useCallback(() => {
     if (!cameraControllerRef.current || !cameraRef.current) return
 
-    if (introTimeoutRef.current) {
-      clearTimeout(introTimeoutRef.current)
-      introTimeoutRef.current = null
-    }
-
     setSelectedInscription(null)
     setInteractionMode(InteractionMode.About)
     setTitleVisible(true)
     setHasInteracted(false)
     setIsIntroTransitioning(false)
-    setIsInteracting(false)
     setHasViewChanged(false)
     clearInscriptionHash()
     setAboutHash()
@@ -450,10 +423,6 @@ function PiacenzaLiverScene({
           undefined,
           modelMatrix,
         )
-        // Clear any existing timeout before setting a new one
-        if (panelTimeoutRef.current) {
-          clearTimeout(panelTimeoutRef.current)
-        }
       }
     },
     [
@@ -534,8 +503,6 @@ function PiacenzaLiverScene({
     if (liverModelRef.current) {
       liverModelRef.current.setHoveredInscription(0)
     }
-
-    setIsInteracting(false)
   }, [setInteractionMode, isSmallScreen, isPortrait])
 
   const handleZoomDetected = useCallback(() => {
@@ -578,28 +545,13 @@ function PiacenzaLiverScene({
   useEffect(() => {
     const container = containerRef.current
     if (container) {
-      if (isInteracting) {
-        container.classList.add("interacting")
-      } else {
-        container.classList.remove("interacting")
-      }
-
-      // Add or remove interacted class based on state
       if (hasInteracted) {
         container.classList.add("interacted")
       } else {
         container.classList.remove("interacted")
       }
     }
-  }, [isInteracting, hasInteracted])
-
-  useEffect(() => {
-    const handleResize = () => {
-      setViewportKey((current) => current + 1)
-    }
-    window.addEventListener("resize", handleResize)
-    return () => window.removeEventListener("resize", handleResize)
-  }, [])
+  }, [hasInteracted])
 
   useEffect(() => {
     if (!cameraRef.current || !controlsRef.current) return
@@ -714,12 +666,11 @@ function PiacenzaLiverScene({
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.5))
     container.appendChild(renderer.domElement)
     rendererRef.current = renderer
-    // Expose just the renderer for the offline profiler (scripts/profiler.html).
-    // We deliberately do NOT expose the THREE namespace itself — that would
-    // defeat the bundler's tree-shaking and re-add ~200KB of unused modules.
-    ;(
-      window as unknown as { __threeRenderer?: THREE.WebGLRenderer }
-    ).__threeRenderer = renderer
+    if (import.meta.env.DEV) {
+      ;(
+        window as unknown as { __threeRenderer?: THREE.WebGLRenderer }
+      ).__threeRenderer = renderer
+    }
     const controls = new OrbitControls(camera, renderer.domElement)
     controls.enableDamping = false
     controls.maxPolarAngle = Math.PI
@@ -767,8 +718,16 @@ function PiacenzaLiverScene({
     cameraControllerRef.current = cameraController
 
     try {
-      const liverModel = new LiverModel(scene, setLoadingProgress)
+      const liverModel = new LiverModel(scene, setLoadingProgress, () => {
+        setErrorMsg(
+          "The 3D model could not be loaded. Please refresh the page or try again later.",
+        )
+        setIsLoading(false)
+      })
       liverModelRef.current = liverModel
+      liverModel.setOnRenderRequired(() => {
+        renderRequestedRef.current = true
+      })
     } catch (e: unknown) {
       console.error("Failed to initialize LiverModel:", e)
       setErrorMsg(
@@ -809,6 +768,8 @@ function PiacenzaLiverScene({
       camera.aspect = width / height
       camera.updateProjectionMatrix()
       renderer.setSize(width, height)
+      setViewportKey((current) => current + 1)
+      renderRequestedRef.current = true
     }
     window.addEventListener("resize", handleResize)
 
@@ -832,13 +793,14 @@ function PiacenzaLiverScene({
       const dt = now - lastFrameTime
       lastFrameTime = now
 
-      controls.update()
-
-      // Detect movement (controls.update mutates camera when damping is active)
+      // OrbitControls applies user input directly, and camera animations call
+      // update themselves. With damping disabled, no per-frame update is needed.
       const moved =
         prevCamPos.distanceToSquared(camera.position) > 1e-8 ||
         prevTarget.distanceToSquared(controls.target) > 1e-8 ||
         prevCamQuat.angleTo(camera.quaternion) > 1e-5
+      const renderRequested = renderRequestedRef.current
+      renderRequestedRef.current = false
       if (moved) {
         prevCamPos.copy(camera.position)
         prevCamQuat.copy(camera.quaternion)
@@ -848,10 +810,14 @@ function PiacenzaLiverScene({
         staticFrames++
       }
 
-      // Particles: real fixed-rate update at ~30fps via dt accumulator.
+      // Particles animate only while the scene is actively rendering.
       particleAccumulator += dt
       let particlesUpdated = false
-      if (particleAccumulator >= 33 && particleRefs.current.particles) {
+      if (
+        (moved || renderRequested || staticFrames < 30) &&
+        particleAccumulator >= 33 &&
+        particleRefs.current.particles
+      ) {
         particleAccumulator = 0
         const {
           particlePositions,
@@ -921,11 +887,8 @@ function PiacenzaLiverScene({
           t * (cameraFillIntensity - cameraFillIntensityClose)
       }
 
-      // On-demand rendering: skip the render call when nothing visible has
-      // changed. We still draw at least every other frame for the first 30
-      // idle frames (covers any animation tails — gsap etc), then we render
-      // only on real change or particle update.
-      const needsRender = moved || particlesUpdated || staticFrames < 30
+      const needsRender =
+        moved || renderRequested || particlesUpdated || staticFrames < 30
       if (needsRender) {
         renderer.render(scene, camera)
       }
@@ -937,15 +900,14 @@ function PiacenzaLiverScene({
         cancelAnimationFrame(animationIdRef.current)
       }
 
-      // Clear any pending panel timeout
-      if (panelTimeoutRef.current) {
-        clearTimeout(panelTimeoutRef.current)
-        panelTimeoutRef.current = null
-      }
-      if (introTimeoutRef.current) {
-        clearTimeout(introTimeoutRef.current)
-        introTimeoutRef.current = null
-      }
+      renderer.domElement.removeEventListener(
+        "webglcontextlost",
+        handleContextLoss,
+      )
+      renderer.domElement.removeEventListener(
+        "webglcontextrestored",
+        handleContextRestore,
+      )
 
       // Clear mouse move timeout
       if (mouseMoveTimeoutRef.current) {
@@ -956,11 +918,26 @@ function PiacenzaLiverScene({
       cameraController?.dispose()
       liverModelRef.current?.dispose()
       interactionManagerRef.current?.dispose()
+      controls.dispose()
+
+      cameraControllerRef.current = null
+      liverModelRef.current = null
+      interactionManagerRef.current = null
+      controlsRef.current = null
+      cameraRef.current = null
+      rendererRef.current = null
+      sceneRef.current = null
+      cameraFillLightRef.current = null
+      cameraFillTargetRef.current = null
 
       renderer.dispose()
       scene.clear()
 
       window.removeEventListener("resize", handleResize)
+      if (import.meta.env.DEV) {
+        delete (window as unknown as { __threeRenderer?: THREE.WebGLRenderer })
+          .__threeRenderer
+      }
 
       if (container.contains(renderer.domElement)) {
         container.removeChild(renderer.domElement)
@@ -969,45 +946,56 @@ function PiacenzaLiverScene({
   }, [setIsLoading, setLoadingProgress])
   useEffect(() => {
     if (
-      rendererRef.current &&
-      cameraRef.current &&
-      controlsRef.current &&
-      liverModelRef.current
+      !isSceneReady ||
+      !rendererRef.current ||
+      !cameraRef.current ||
+      !controlsRef.current ||
+      !liverModelRef.current
     ) {
-      if (interactionManagerRef.current) {
-        interactionManagerRef.current.dispose()
-      }
-
-      const interactionManager = new InteractionManager(
-        rendererRef.current,
-        cameraRef.current,
-        controlsRef.current,
-        liverModelRef.current,
-        liverInscriptions,
-        {
-          onInscriptionClick: handleInscriptionClick,
-          onBackgroundClick: handleBackgroundClick,
-          onMarkerHover: handleMarkerHover,
-          onZoomDetected: handleZoomDetected,
-          onModelRotate: handleModelRotate,
-          onMouseMove: handleMouseMove,
-          onModifierKeyChange: handleModifierKeyChange,
-          onReset: handleReset,
-          onViewChange: handleViewChange,
-        },
-      )
-      interactionManager.setInteractionEnabled(
-        interactionMode === InteractionMode.ThreeD ||
-          interactionMode === InteractionMode.Inscription,
-      )
-      interactionManager.setHoverEnabled(
-        interactionMode === InteractionMode.ThreeD ||
-          interactionMode === InteractionMode.Inscription,
-      )
-      interactionManager.setClickEnabled(true)
-      interactionManagerRef.current = interactionManager
+      return
     }
+
+    const callbacks = {
+      onInscriptionClick: handleInscriptionClick,
+      onBackgroundClick: handleBackgroundClick,
+      onMarkerHover: handleMarkerHover,
+      onZoomDetected: handleZoomDetected,
+      onModelRotate: handleModelRotate,
+      onMouseMove: handleMouseMove,
+      onModifierKeyChange: handleModifierKeyChange,
+      onReset: handleReset,
+      onViewChange: handleViewChange,
+      onRenderRequired: () => {
+        renderRequestedRef.current = true
+      },
+    }
+
+    const isInteractive =
+      interactionMode === InteractionMode.ThreeD ||
+      interactionMode === InteractionMode.Inscription
+
+    if (interactionManagerRef.current) {
+      interactionManagerRef.current.updateCallbacks(callbacks)
+      interactionManagerRef.current.setInteractionEnabled(isInteractive)
+      interactionManagerRef.current.setHoverEnabled(isInteractive)
+      interactionManagerRef.current.setClickEnabled(true)
+      return
+    }
+
+    const interactionManager = new InteractionManager(
+      rendererRef.current,
+      cameraRef.current,
+      controlsRef.current,
+      liverModelRef.current,
+      liverInscriptions,
+      callbacks,
+    )
+    interactionManager.setInteractionEnabled(isInteractive)
+    interactionManager.setHoverEnabled(isInteractive)
+    interactionManager.setClickEnabled(true)
+    interactionManagerRef.current = interactionManager
   }, [
+    isSceneReady,
     handleInscriptionClick,
     handleBackgroundClick,
     handleMarkerHover,
@@ -1089,13 +1077,17 @@ function PiacenzaLiverScene({
           liverModelRef.current.getModelMatrix() || new THREE.Matrix4()
 
         // Use a small delay to ensure state updates are processed
-        setTimeout(() => {
+        if (hashNavigationTimeoutRef.current) {
+          clearTimeout(hashNavigationTimeoutRef.current)
+        }
+        hashNavigationTimeoutRef.current = window.setTimeout(() => {
           handleInscriptionClick({
             inscriptionId,
             cameraLocalPosition: inscription.cameraPosition,
             cameraLocalTarget: inscription.cameraTarget,
             modelMatrix,
           })
+          hashNavigationTimeoutRef.current = null
         }, 100)
       }
     }
@@ -1110,7 +1102,13 @@ function PiacenzaLiverScene({
       handleHashNavigation()
     }
     window.addEventListener("hashchange", handleHashChange)
-    return () => window.removeEventListener("hashchange", handleHashChange)
+    return () => {
+      window.removeEventListener("hashchange", handleHashChange)
+      if (hashNavigationTimeoutRef.current) {
+        clearTimeout(hashNavigationTimeoutRef.current)
+        hashNavigationTimeoutRef.current = null
+      }
+    }
   }, [
     isSceneReady,
     hasInteracted,

--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -721,8 +721,7 @@ function PiacenzaLiverScene({
       window as unknown as { __threeRenderer?: THREE.WebGLRenderer }
     ).__threeRenderer = renderer
     const controls = new OrbitControls(camera, renderer.domElement)
-    controls.enableDamping = true
-    controls.dampingFactor = 0.05
+    controls.enableDamping = false
     controls.maxPolarAngle = Math.PI
     controls.minDistance = 1.5
     controls.maxDistance = 10

--- a/src/camera/Controller.ts
+++ b/src/camera/Controller.ts
@@ -19,12 +19,8 @@ const getFinalCameraPosition = () => {
 export class CameraController {
   private camera: THREE.Camera
   private controls: OrbitControls
-  private lastManualPosition: THREE.Vector3
-  private lastManualTarget: THREE.Vector3
   private isAnimating: boolean
-  private currentAnimationId: string | null
   private originalControlsEnabled: boolean
-  private originalEnableDamping: boolean
   private controlsTemporarilyDisabled: boolean
   private currentTween: gsap.core.Tween | null = null
 
@@ -32,29 +28,14 @@ export class CameraController {
     this.camera = camera
     this.controls = controls
 
-    // Track user's manual positions
-    // Use final camera position from config
-    const endPos = getFinalCameraPosition()
-    const endTarget = new THREE.Vector3(0, 0, 0)
-    this.lastManualPosition = endPos
-    this.lastManualTarget = endTarget
-
-    // Animation state
     this.isAnimating = false
-    this.currentAnimationId = null
     this.originalControlsEnabled = controls.enabled
-    this.originalEnableDamping = controls.enableDamping
     this.controlsTemporarilyDisabled = false
 
     // Bind methods
-    this.handleControlsChange = this.handleControlsChange.bind(this)
     this.handleControlsStart = this.handleControlsStart.bind(this)
-    this.handleControlsEnd = this.handleControlsEnd.bind(this)
 
-    // Listen for manual camera movements
-    this.controls.addEventListener("change", this.handleControlsChange)
     this.controls.addEventListener("start", this.handleControlsStart)
-    this.controls.addEventListener("end", this.handleControlsEnd)
   }
 
   private ensureSafeEndPose(
@@ -91,23 +72,6 @@ export class CameraController {
     }
   }
 
-  // Handle when user stops manual control
-  handleControlsEnd() {
-    // Update manual position when user finishes controlling
-    if (!this.isAnimating) {
-      this.lastManualPosition.copy(this.camera.position)
-      this.lastManualTarget.copy(this.controls.target)
-    }
-  }
-
-  // Track manual camera movements (only when not animating)
-  handleControlsChange() {
-    if (!this.isAnimating) {
-      this.lastManualPosition.copy(this.camera.position)
-      this.lastManualTarget.copy(this.controls.target)
-    }
-  }
-
   // Animate camera to focus on a specific position with panel-aware positioning and proper text orientation
   focusOn(
     targetPosition: THREE.Vector3,
@@ -119,10 +83,6 @@ export class CameraController {
   ) {
     // Stop any existing animation first
     this.stopAnimation()
-
-    // Store current position before animating
-    this.lastManualPosition.copy(this.camera.position)
-    this.lastManualTarget.copy(this.controls.target)
 
     // TODO: Use isPanelOpen for panel-aware camera positioning
     // Currently unused but reserved for future panel positioning logic
@@ -152,9 +112,7 @@ export class CameraController {
 
     // Temporarily disable controls to avoid fighting during animation
     this.originalControlsEnabled = this.controls.enabled
-    this.originalEnableDamping = this.controls.enableDamping
     this.controls.enabled = false
-    this.controls.enableDamping = false
     this.controlsTemporarilyDisabled = true
     this.isAnimating = true
 
@@ -172,13 +130,12 @@ export class CameraController {
           // Simple lerp for position and target
           this.camera.position.lerpVectors(startPosition, endPosition, t)
           this.controls.target.lerpVectors(startTarget, endTarget, t)
+          this.controls.update()
         },
         onComplete: () => {
           this.isAnimating = false
-          this.currentAnimationId = null
           if (this.controlsTemporarilyDisabled) {
             this.controls.enabled = this.originalControlsEnabled
-            this.controls.enableDamping = this.originalEnableDamping
             this.controlsTemporarilyDisabled = false
           }
           this.controls.update()
@@ -191,59 +148,6 @@ export class CameraController {
     this.isAnimating = true
     this.currentTween = tween
     return "camera-focus-gsap"
-  }
-
-  // Intro camera animation
-  playIntroAnimation(onComplete?: () => void, finalTarget?: THREE.Vector3) {
-    this.stopAnimation()
-
-    const startPos = this.camera.position.clone()
-    const endPos = getFinalCameraPosition()
-    const endTarget = finalTarget?.clone() || new THREE.Vector3(0, 0, 0)
-
-    // Start with the camera looking at the origin, then smoothly transition to the liver center
-    const startTarget = new THREE.Vector3(0, 0, 0)
-    const duration = SceneConfig.camera.animationDuration
-
-    this.isAnimating = true
-    const tween = gsap.to(
-      { t: 0 },
-      {
-        t: 1,
-        duration: duration / 1000,
-        ease: "power2.inOut",
-        onUpdate: () => {
-          if (this.currentTween !== tween || !this.isAnimating) return
-          const t = (tween.targets()[0] as { t: number }).t
-
-          const tempCameraPos = new THREE.Vector3().lerpVectors(
-            startPos,
-            endPos,
-            t,
-          )
-          const tempTargetPos = new THREE.Vector3().lerpVectors(
-            startTarget,
-            endTarget,
-            t,
-          )
-
-          this.camera.position.copy(tempCameraPos)
-          this.controls.target.copy(tempTargetPos)
-          this.controls.update()
-        },
-        onComplete: () => {
-          if (this.currentTween !== tween) return
-          this.isAnimating = false
-          this.currentTween = null
-          this.lastManualPosition.copy(endPos)
-          this.lastManualTarget.copy(endTarget)
-          if (onComplete) onComplete()
-        },
-      },
-    )
-    this.currentTween = tween
-    this.currentAnimationId = "camera-intro-gsap"
-    return "camera-intro-gsap"
   }
 
   // Reset camera and model to default positions
@@ -260,9 +164,6 @@ export class CameraController {
     const endPosition = getFinalCameraPosition()
     const endTarget =
       liverModel?.getLiverCenter().clone() || new THREE.Vector3(0, 0, 0)
-
-    this.lastManualPosition.copy(endPosition)
-    this.lastManualTarget.copy(endTarget)
 
     let modelAnimation: ((t: number) => void) | null = null
 
@@ -345,7 +246,6 @@ export class CameraController {
       },
     )
     this.currentTween = tween
-    this.currentAnimationId = "camera-reset-gsap"
     return "camera-reset-gsap"
   }
 
@@ -362,9 +262,6 @@ export class CameraController {
     const endPosition = target
       .clone()
       .add(direction.multiplyScalar(targetDistance))
-
-    this.lastManualPosition.copy(endPosition)
-    this.lastManualTarget.copy(target)
 
     this.isAnimating = true
     const tween = gsap.to(
@@ -395,7 +292,6 @@ export class CameraController {
       },
     )
     this.currentTween = tween
-    this.currentAnimationId = "camera-pullback-gsap"
     return "camera-pullback-gsap"
   }
 
@@ -406,12 +302,10 @@ export class CameraController {
       this.currentTween = null
     }
     this.isAnimating = false
-    this.currentAnimationId = null
 
     // Always restore controls state if we temporarily disabled them
     if (this.controlsTemporarilyDisabled) {
       this.controls.enabled = this.originalControlsEnabled
-      this.controls.enableDamping = this.originalEnableDamping
       this.controlsTemporarilyDisabled = false
     }
 
@@ -419,21 +313,9 @@ export class CameraController {
     this.controls.update()
   }
 
-  // Get current animation ID for external checks
-  getCurrentAnimationId(): string | null {
-    return this.currentAnimationId
-  }
-
-  // Check if currently animating
-  isCurrentlyAnimating(): boolean {
-    return this.isAnimating
-  }
-
   // Cleanup
   dispose() {
-    this.controls.removeEventListener("change", this.handleControlsChange)
     this.controls.removeEventListener("start", this.handleControlsStart)
-    this.controls.removeEventListener("end", this.handleControlsEnd)
     this.stopAnimation()
   }
 }

--- a/src/hooks/useOrientation.ts
+++ b/src/hooks/useOrientation.ts
@@ -7,6 +7,7 @@ export const useOrientation = () => {
   )
 
   useEffect(() => {
+    const timeoutIds: number[] = []
     const updateOrientation = () => {
       const newIsPortrait = window.innerHeight > window.innerWidth
       setIsPortrait(newIsPortrait)
@@ -14,9 +15,9 @@ export const useOrientation = () => {
 
     const handleOrientationChange = () => {
       // Multiple timeouts to catch different timing scenarios
-      setTimeout(updateOrientation, 0)
-      setTimeout(updateOrientation, 100)
-      setTimeout(updateOrientation, 300)
+      timeoutIds.push(window.setTimeout(updateOrientation, 0))
+      timeoutIds.push(window.setTimeout(updateOrientation, 100))
+      timeoutIds.push(window.setTimeout(updateOrientation, 300))
     }
 
     window.addEventListener("resize", updateOrientation)
@@ -30,6 +31,9 @@ export const useOrientation = () => {
       window.removeEventListener("resize", updateOrientation)
       window.removeEventListener("orientationchange", handleOrientationChange)
       observer.disconnect()
+      timeoutIds.forEach((id) => {
+        clearTimeout(id)
+      })
     }
   }, [])
 

--- a/src/hooks/useOrientation.ts
+++ b/src/hooks/useOrientation.ts
@@ -14,6 +14,10 @@ export const useOrientation = () => {
     }
 
     const handleOrientationChange = () => {
+      for (const id of timeoutIds) {
+        clearTimeout(id)
+      }
+      timeoutIds.length = 0
       // Multiple timeouts to catch different timing scenarios
       timeoutIds.push(window.setTimeout(updateOrientation, 0))
       timeoutIds.push(window.setTimeout(updateOrientation, 100))

--- a/src/scene/InteractionManager.ts
+++ b/src/scene/InteractionManager.ts
@@ -24,6 +24,7 @@ export interface InteractionCallbacks {
   onModifierKeyChange: (isPressed: boolean) => void
   onReset: () => void
   onViewChange: () => void
+  onRenderRequired: () => void
 }
 
 export class InteractionManager {
@@ -83,6 +84,7 @@ export class InteractionManager {
   private boundHandleTouchMove: (event: TouchEvent) => void
   private boundHandleTouchEnd: (event: TouchEvent) => void
   private boundHandleDoubleClick: (event: MouseEvent) => void
+  private boundHandleWheel: (event: WheelEvent) => void
 
   constructor(
     renderer: THREE.WebGLRenderer,
@@ -111,6 +113,7 @@ export class InteractionManager {
     this.boundHandleTouchMove = this.handleTouchMove.bind(this)
     this.boundHandleTouchEnd = this.handleTouchEnd.bind(this)
     this.boundHandleDoubleClick = this.handleDoubleClick.bind(this)
+    this.boundHandleWheel = this.handleWheel.bind(this)
 
     this.setupEventListeners()
   }
@@ -137,7 +140,7 @@ export class InteractionManager {
     })
 
     // Wheel event
-    domElement.addEventListener("wheel", this.handleWheel.bind(this), {
+    domElement.addEventListener("wheel", this.boundHandleWheel, {
       passive: true,
     })
 
@@ -149,10 +152,7 @@ export class InteractionManager {
   }
 
   private updateMode() {
-    const shouldBeInNavigationMode =
-      this.isShiftPressed ||
-      this.isRotatingModel ||
-      (this.isShiftPressed && this.isMetaPressed)
+    const shouldBeInNavigationMode = this.isShiftPressed || this.isRotatingModel
 
     const newMode = shouldBeInNavigationMode
       ? InteractionManagerMode.ModelNavigation
@@ -182,6 +182,23 @@ export class InteractionManager {
   private _rotQY = new THREE.Quaternion()
   private _rotQX = new THREE.Quaternion()
   private _rotCombined = new THREE.Quaternion()
+  private hasRotationPivot = false
+  private modelRotationNotified = false
+
+  private beginModelRotation(): void {
+    const liverObject = this.liverModel.getObject()
+    if (!liverObject) return
+
+    liverObject.updateMatrixWorld(false)
+    this._rotBox.makeEmpty().setFromObject(liverObject)
+    this._rotBox.getCenter(this._rotCenter)
+    this.hasRotationPivot = true
+    this.modelRotationNotified = false
+  }
+
+  private endModelRotation(): void {
+    this.hasRotationPivot = false
+  }
 
   private rotateModelAroundCenter(
     deltaX: number,
@@ -194,8 +211,9 @@ export class InteractionManager {
     liverObject.updateMatrixWorld(false)
     this.camera.updateMatrixWorld(false)
 
-    this._rotBox.makeEmpty().setFromObject(liverObject)
-    this._rotBox.getCenter(this._rotCenter)
+    if (!this.hasRotationPivot) {
+      this.beginModelRotation()
+    }
 
     liverObject.getWorldPosition(this._rotWorldPos)
     this._rotOffset.copy(this._rotWorldPos).sub(this._rotCenter)
@@ -217,7 +235,11 @@ export class InteractionManager {
 
     liverObject.position.add(this._rotOffset)
     liverObject.updateMatrixWorld(true)
-    this.callbacks.onModelRotate()
+    this.callbacks.onRenderRequired()
+    if (!this.modelRotationNotified) {
+      this.modelRotationNotified = true
+      this.callbacks.onModelRotate()
+    }
   }
 
   private hasMovedBeyondThreshold(
@@ -240,6 +262,7 @@ export class InteractionManager {
     // Check if Shift is pressed for model rotation
     if (this.isShiftPressed) {
       this.isRotatingModel = true
+      this.beginModelRotation()
       this.controls.enabled = false // Disable camera controls
       this.updateMode()
       event.preventDefault()
@@ -250,6 +273,7 @@ export class InteractionManager {
     if (!this.interactionEnabled) return
     if (this.isRotatingModel) {
       this.isRotatingModel = false
+      this.endModelRotation()
       this.controls.enabled = true // Re-enable camera controls
       // If we moved during rotation, mark that we shouldn't process clicks
       if (this.hasMovedDuringRotation) {
@@ -407,6 +431,7 @@ export class InteractionManager {
       modifierChanged = true
       if (this.isRotatingModel) {
         this.isRotatingModel = false
+        this.endModelRotation()
         this.controls.enabled = true
       }
     }
@@ -564,6 +589,7 @@ export class InteractionManager {
     if (event.touches.length === 3) {
       // 3-finger touch for model rotation
       this.isThreeFingerTouch = true
+      this.beginModelRotation()
       this.isMultiTouch = false
       const touch = event.touches[0] // Use first touch as reference
       this.lastThreeFingerPosition = { x: touch.clientX, y: touch.clientY }
@@ -666,6 +692,7 @@ export class InteractionManager {
     // Reset 3-finger touch state
     if (this.isThreeFingerTouch) {
       this.isThreeFingerTouch = false
+      this.endModelRotation()
       this.lastThreeFingerPosition = null
       this.touchStartPosition = null
       this.touchMovedDuringTouch = false
@@ -774,12 +801,12 @@ export class InteractionManager {
     }
   }
 
-  public isCurrentlyPanningOrRotating(): boolean {
-    return this.isPanningOrRotating
-  }
-
   public setInitialCameraDistance(distance: number) {
     this.initialCameraDistance = distance
+  }
+
+  public updateCallbacks(callbacks: InteractionCallbacks) {
+    this.callbacks = callbacks
   }
 
   public setIntroAnimationMode(enabled: boolean) {
@@ -795,6 +822,7 @@ export class InteractionManager {
     if (!enabled) {
       this.isPanningOrRotating = false
       this.isRotatingModel = false
+      this.endModelRotation()
       this.isShiftPressed = false
       this.isMetaPressed = false
       this.mouseDownPosition = null
@@ -934,7 +962,7 @@ export class InteractionManager {
     domElement.removeEventListener("touchend", this.boundHandleTouchEnd)
 
     // Wheel event
-    domElement.removeEventListener("wheel", this.handleWheel.bind(this))
+    domElement.removeEventListener("wheel", this.boundHandleWheel)
 
     // Keyboard and control events
     window.removeEventListener("keydown", this.boundHandleKeyDown)

--- a/src/scene/InteractionManager.ts
+++ b/src/scene/InteractionManager.ts
@@ -896,7 +896,7 @@ export class InteractionManager {
 
   private performHoverRaycast(clientX: number, clientY: number) {
     if (!this.hoverEnabled || !this.interactionEnabled) return
-    if (!this.liverModel.getMaskTexture()) return
+    if (!this.liverModel.hasMaskIds()) return
 
     // Disable hover highlighting in model navigation mode
     if (this.currentMode === InteractionManagerMode.ModelNavigation) {

--- a/src/scene/LiverModel.ts
+++ b/src/scene/LiverModel.ts
@@ -517,10 +517,8 @@ export class LiverModel {
     return this.object
   }
 
-  getMaskTexture() {
-    // Truthy presence check for hover raycasting; the buffer itself is used
-    // by getInscriptionAtUV.
-    return this.maskIds
+  hasMaskIds() {
+    return this.maskIds != null
   }
 
   setHoveredInscription(inscriptionId: number) {
@@ -674,6 +672,8 @@ export class LiverModel {
   }
 
   dispose() {
+    this.stopPulseAnimation()
+
     // Use Three.js traverse to dispose of all meshes and materials
     const disposeObject = (obj: THREE.Object3D | null) => {
       if (!obj) return
@@ -721,12 +721,17 @@ export class LiverModel {
     this.maskHeight = 0
   }
 
+  private pulseTimeoutIds: number[] = []
+  private pulseTweens: gsap.core.Tween[] = []
+  private pulseOverlays: THREE.Mesh[] = []
+
   // Pulse animation - only runs once on initial load
   pulseAllInscriptions() {
     if (!this.mesh || !this.hoveredMaterial) return
 
+    this.stopPulseAnimation()
+
     const inscriptions = liverInscriptions.slice()
-    const overlays: THREE.Mesh[] = []
     const config = SceneConfig.pulse
 
     // Use desktop animation for all devices
@@ -737,25 +742,28 @@ export class LiverModel {
       this.onRenderRequired?.()
     }
 
+    const removeOverlay = (overlay: THREE.Mesh) => {
+      const overlayIndex = this.pulseOverlays.indexOf(overlay)
+      if (overlayIndex >= 0) this.pulseOverlays.splice(overlayIndex, 1)
+      ;(overlay.parent || this.scene).remove(overlay)
+      if (Array.isArray(overlay.material)) {
+        overlay.material.forEach((mat) => {
+          mat.dispose()
+        })
+      } else {
+        overlay.material.dispose()
+      }
+    }
+
     const addNext = () => {
       if (index >= inscriptions.length) {
         return
       }
 
       // Limit concurrent meshes to prevent performance issues
-      if (overlays.length >= maxConcurrentMeshes) {
-        // Remove oldest overlay
-        const oldestOverlay = overlays.shift()
-        if (oldestOverlay) {
-          ;(oldestOverlay.parent || this.scene).remove(oldestOverlay)
-          if (Array.isArray(oldestOverlay.material)) {
-            oldestOverlay.material.forEach((mat) => {
-              mat.dispose()
-            })
-          } else {
-            oldestOverlay.material.dispose()
-          }
-        }
+      if (this.pulseOverlays.length >= maxConcurrentMeshes) {
+        const oldestOverlay = this.pulseOverlays[0]
+        if (oldestOverlay) removeOverlay(oldestOverlay)
       }
 
       // Create overlay for current inscription
@@ -775,29 +783,53 @@ export class LiverModel {
       mesh.scale.copy(this.mesh.scale)
 
       ;(this.mesh?.parent || this.scene).add(mesh)
-      overlays.push(mesh)
+      this.pulseOverlays.push(mesh)
       requestPulseRender()
 
       // Fade out this inscription after TRAIL_DURATION
-      setTimeout(() => {
-        gsap.to(material, {
+      const fadeTimeoutId = window.setTimeout(() => {
+        const tween = gsap.to(material, {
           opacity: 0,
           duration: config.individualFadeDuration,
           ease: "power2.in",
           onUpdate: requestPulseRender,
           onComplete: () => {
-            ;(mesh.parent || this.scene).remove(mesh)
-            material.dispose()
+            removeOverlay(mesh)
             requestPulseRender()
           },
         })
+        this.pulseTweens.push(tween)
       }, config.trailDuration)
+      this.pulseTimeoutIds.push(fadeTimeoutId)
 
       // Move to next inscription
-      setTimeout(addNext, config.trailSpeed)
+      const nextTimeoutId = window.setTimeout(addNext, config.trailSpeed)
+      this.pulseTimeoutIds.push(nextTimeoutId)
       index++
     }
 
     addNext()
+  }
+
+  private stopPulseAnimation() {
+    for (const id of this.pulseTimeoutIds) {
+      clearTimeout(id)
+    }
+    this.pulseTimeoutIds = []
+    for (const tween of this.pulseTweens) {
+      tween.kill()
+    }
+    this.pulseTweens = []
+    for (const overlay of [...this.pulseOverlays]) {
+      ;(overlay.parent || this.scene).remove(overlay)
+      if (Array.isArray(overlay.material)) {
+        overlay.material.forEach((mat) => {
+          mat.dispose()
+        })
+      } else {
+        overlay.material.dispose()
+      }
+    }
+    this.pulseOverlays = []
   }
 }

--- a/src/scene/LiverModel.ts
+++ b/src/scene/LiverModel.ts
@@ -1,6 +1,5 @@
 import { gsap } from "gsap"
 import * as THREE from "three"
-import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js"
 import objUrl from "../assets/liver-model/Fegato.obj"
 import baseColorUrl from "../assets/liver-model/Fegato_baseColor.jpg"
@@ -18,6 +17,8 @@ export class LiverModel {
   private mesh: THREE.Mesh | null = null
   private object: THREE.Object3D | null = null
   private onProgress?: (progress: number) => void
+  private onError?: (error: unknown) => void
+  private onRenderRequired?: () => void
   private loadingManager: THREE.LoadingManager
   private lastProgress: number = 0
   private liverCenter: THREE.Vector3 = new THREE.Vector3(0, 0, 0)
@@ -88,9 +89,14 @@ export class LiverModel {
   // 4 GPU textures (base, normal, ORM, atlas) + 1 raw mask image + 1 OBJ + 1 font = 7
   private totalAssets = 7
 
-  constructor(scene: THREE.Scene, onProgress?: (progress: number) => void) {
+  constructor(
+    scene: THREE.Scene,
+    onProgress?: (progress: number) => void,
+    onError?: (error: unknown) => void,
+  ) {
     this.scene = scene
     this.onProgress = onProgress
+    this.onError = onError
     this.loadingManager = new THREE.LoadingManager()
 
     if (!this.checkWebGLSupport()) {
@@ -98,7 +104,7 @@ export class LiverModel {
       throw new Error("WebGL not supported")
     }
 
-    this.loadLiverModel()
+    void this.loadLiverModel().catch((error) => this.onError?.(error))
   }
 
   private checkWebGLSupport(): boolean {
@@ -180,14 +186,6 @@ export class LiverModel {
   // Getter for the calculated liver center
   getLiverCenter(): THREE.Vector3 {
     return this.liverCenter.clone()
-  }
-
-  // Method to reset camera target to liver center
-  resetCameraToCenter(controls?: OrbitControls) {
-    if (this.liverCenter && controls) {
-      controls.target.copy(this.liverCenter)
-      console.log("Camera target reset to liver center:", this.liverCenter)
-    }
   }
 
   private markAssetLoaded() {
@@ -471,16 +469,18 @@ export class LiverModel {
       object.visible = true
       this.calculateLiverCenter()
 
-      ;(
-        window as typeof window & {
-          liverAtlas?: {
-            set: (t: Partial<AtlasTweak>) => void
-            get: () => AtlasTweak
+      if (import.meta.env.DEV) {
+        ;(
+          window as typeof window & {
+            liverAtlas?: {
+              set: (t: Partial<AtlasTweak>) => void
+              get: () => AtlasTweak
+            }
           }
+        ).liverAtlas = {
+          set: (t: Partial<AtlasTweak>) => this.setAtlasTweak(t),
+          get: () => this.getAtlasTweak(),
         }
-      ).liverAtlas = {
-        set: (t: Partial<AtlasTweak>) => this.setAtlasTweak(t),
-        get: () => this.getAtlasTweak(),
       }
 
       // Complete load
@@ -518,13 +518,17 @@ export class LiverModel {
   }
 
   setHoveredInscription(inscriptionId: number) {
+    if (this.currentHoveredId === inscriptionId) return
     this.currentHoveredId = inscriptionId
     this.updateHoveredHighlight()
+    this.onRenderRequired?.()
   }
 
   setSelectedInscription(inscriptionId: number) {
+    if (this.currentSelectedId === inscriptionId) return
     this.currentSelectedId = inscriptionId
     this.updateSelectedHighlight()
+    this.onRenderRequired?.()
   }
 
   getSelectedInscriptionId(): number {
@@ -667,6 +671,10 @@ export class LiverModel {
     this.onModelReady = callback
   }
 
+  setOnRenderRequired(callback: () => void) {
+    this.onRenderRequired = callback
+  }
+
   dispose() {
     // Use Three.js traverse to dispose of all meshes and materials
     const disposeObject = (obj: THREE.Object3D | null) => {
@@ -726,6 +734,10 @@ export class LiverModel {
     let index = 0
     const maxConcurrentMeshes = 5 // Limit concurrent meshes
 
+    const requestPulseRender = () => {
+      this.onRenderRequired?.()
+    }
+
     const addNext = () => {
       if (index >= inscriptions.length) {
         return
@@ -765,6 +777,7 @@ export class LiverModel {
 
       ;(this.mesh?.parent || this.scene).add(mesh)
       overlays.push(mesh)
+      requestPulseRender()
 
       // Fade out this inscription after TRAIL_DURATION
       setTimeout(() => {
@@ -772,9 +785,11 @@ export class LiverModel {
           opacity: 0,
           duration: config.individualFadeDuration,
           ease: "power2.in",
+          onUpdate: requestPulseRender,
           onComplete: () => {
             ;(mesh.parent || this.scene).remove(mesh)
             material.dispose()
+            requestPulseRender()
           },
         })
       }, config.trailDuration)

--- a/src/scene/LiverModel.ts
+++ b/src/scene/LiverModel.ts
@@ -41,9 +41,10 @@ export class LiverModel {
     return { ...this.atlasTweak }
   }
 
-  // Offscreen canvas for CPU-side sampling of the segmentation mask
-  private maskCanvas: HTMLCanvasElement | null = null
-  private maskCtx: CanvasRenderingContext2D | null = null
+  // CPU-side segmentation mask for inscription picking. Drawn once into a
+  // canvas at load, then copied into a compact red-channel buffer so hover
+  // raycasts never call getImageData per sample.
+  private maskIds: Uint8Array | null = null
   private maskWidth = 0
   private maskHeight = 0
 
@@ -314,30 +315,34 @@ export class LiverModel {
         this.labelToTile[n] = { row: labelsObj[k].row, col: labelsObj[k].col }
       })
 
-      // Prepare offscreen canvas for mask sampling. We can downsample the
-      // 4096² mask to 1024² with no measurable accuracy loss for the inscription
-      // picker — the labelled regions are large patches, not pixel features.
-      // 16× less memory for the canvas and 16× faster getImageData calls.
+      // Prepare a compact CPU mask buffer. We downsample the 4096² mask to
+      // 1024² with no measurable accuracy loss for the inscription picker —
+      // the labelled regions are large patches, not pixel features.
       if (maskImage.width && maskImage.height) {
         const downscale = 4
         this.maskWidth = Math.max(1, Math.floor(maskImage.width / downscale))
         this.maskHeight = Math.max(1, Math.floor(maskImage.height / downscale))
-        this.maskCanvas = document.createElement("canvas")
-        this.maskCanvas.width = this.maskWidth
-        this.maskCanvas.height = this.maskHeight
-        this.maskCtx = this.maskCanvas.getContext("2d", {
+        const maskCanvas = document.createElement("canvas")
+        maskCanvas.width = this.maskWidth
+        maskCanvas.height = this.maskHeight
+        const maskCtx = maskCanvas.getContext("2d", {
           willReadFrequently: true,
         })
-        if (this.maskCtx) {
+        if (maskCtx) {
           // Use nearest-neighbor when downsampling so label IDs are not blended.
-          this.maskCtx.imageSmoothingEnabled = false
-          this.maskCtx.drawImage(
-            maskImage,
+          maskCtx.imageSmoothingEnabled = false
+          maskCtx.drawImage(maskImage, 0, 0, this.maskWidth, this.maskHeight)
+          const rgba = maskCtx.getImageData(
             0,
             0,
             this.maskWidth,
             this.maskHeight,
-          )
+          ).data
+          const ids = new Uint8Array(this.maskWidth * this.maskHeight)
+          for (let i = 0, j = 0; i < rgba.length; i += 4, j++) {
+            ids[j] = rgba[i]
+          }
+          this.maskIds = ids
         }
       }
 
@@ -513,8 +518,9 @@ export class LiverModel {
   }
 
   getMaskTexture() {
-    // Return the segmentation mask texture used for UV-based inscription picking
-    return this.maskCanvas ? { image: this.maskCanvas } : null
+    // Truthy presence check for hover raycasting; the buffer itself is used
+    // by getInscriptionAtUV.
+    return this.maskIds
   }
 
   setHoveredInscription(inscriptionId: number) {
@@ -639,13 +645,7 @@ export class LiverModel {
   }
 
   getInscriptionAtUV(_u: number, _v: number): number {
-    if (
-      !this.maskCtx ||
-      !this.maskCanvas ||
-      this.maskWidth === 0 ||
-      this.maskHeight === 0
-    )
-      return 0
+    if (!this.maskIds || this.maskWidth === 0 || this.maskHeight === 0) return 0
     // Clamp uv to [0,1]
     const u = Math.min(1, Math.max(0, _u))
     const v = Math.min(1, Math.max(0, _v))
@@ -658,9 +658,7 @@ export class LiverModel {
       this.maskHeight - 1,
       Math.max(0, Math.floor((1 - v) * this.maskHeight)),
     )
-    const data = this.maskCtx.getImageData(x, y, 1, 1).data
-    const id = data[0] // red channel encodes id 0..255
-    return id
+    return this.maskIds[y * this.maskWidth + x]
   }
 
   getModelMatrix(): THREE.Matrix4 {
@@ -718,8 +716,9 @@ export class LiverModel {
     })
     this.textureCloneCache.clear()
 
-    this.maskCanvas = null
-    this.maskCtx = null
+    this.maskIds = null
+    this.maskWidth = 0
+    this.maskHeight = 0
   }
 
   // Pulse animation - only runs once on initial load

--- a/src/ui/DeityPanel.tsx
+++ b/src/ui/DeityPanel.tsx
@@ -1,7 +1,7 @@
 import { Box, Drawer, Paper, Stack, Title } from "@mantine/core"
 import { useMediaQuery } from "@mantine/hooks"
 import { useDrag } from "@use-gesture/react"
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useOrientation } from "../hooks/useOrientation"
 import {
@@ -95,14 +95,15 @@ export function DeityPanel({
     return panelHeight
   }
 
-  // Reset to lower third when new inscription is selected
-  if (
-    selectedInscription &&
-    selectedInscription.id !== prevInscriptionId.current
-  ) {
-    setPanelHeight(33)
-    prevInscriptionId.current = selectedInscription.id
-  }
+  useEffect(() => {
+    if (
+      selectedInscription &&
+      selectedInscription.id !== prevInscriptionId.current
+    ) {
+      setPanelHeight(33)
+      prevInscriptionId.current = selectedInscription.id
+    }
+  }, [selectedInscription])
 
   if (!selectedInscription) return null
 

--- a/src/ui/components/BraveDisclaimer.tsx
+++ b/src/ui/components/BraveDisclaimer.tsx
@@ -54,9 +54,11 @@ export function BraveDisclaimer() {
 
     // Since shield detection is unreliable, just show for all Brave users
     // but make it less intrusive by showing after a delay
-    setTimeout(() => {
+    const timeoutId = window.setTimeout(() => {
       setShowModal(true)
     }, 2000)
+
+    return () => clearTimeout(timeoutId)
   }, [])
 
   const handleDismiss = () => {

--- a/src/ui/components/HoverTooltip.tsx
+++ b/src/ui/components/HoverTooltip.tsx
@@ -1,93 +1,131 @@
 import { Paper } from "@mantine/core"
+import {
+  forwardRef,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
 import { isMobile } from "react-device-detect"
 import { getGodsDisplayNames } from "../../scene/LiverData"
 import type { HoveredSection } from "../../types"
 import { NumberBadge } from "./NumberBadge"
 
+export type HoverTooltipHandle = {
+  setPointer: (x: number, y: number, isOverCanvas: boolean) => void
+}
+
 interface HoverTooltipProps {
   hoveredSection: HoveredSection | null
-  mousePosition: { x: number; y: number; isOverCanvas?: boolean }
   isPanelOpen?: boolean
   isModifierKeyPressed?: boolean
   isMouseOverPanel?: boolean
 }
 
-export function HoverTooltip({
-  hoveredSection,
-  mousePosition,
-  isModifierKeyPressed = false,
-  isMouseOverPanel = false,
-}: HoverTooltipProps) {
-  // Don't show tooltip if mobile, no hovered section, modifier keys are pressed, cursor is outside canvas, or cursor is over panel
-  if (
-    !hoveredSection ||
-    isMobile ||
-    isModifierKeyPressed ||
-    mousePosition.isOverCanvas === false ||
-    isMouseOverPanel
+export const HoverTooltip = forwardRef<HoverTooltipHandle, HoverTooltipProps>(
+  function HoverTooltip(
+    { hoveredSection, isModifierKeyPressed = false, isMouseOverPanel = false },
+    ref,
   ) {
-    return null
-  }
+    const rootRef = useRef<HTMLDivElement>(null)
+    const lastPointerRef = useRef({ x: 0, y: 0 })
+    const overCanvasRef = useRef(true)
+    const [isOverCanvas, setIsOverCanvas] = useState(true)
 
-  const deityNames = getGodsDisplayNames(hoveredSection.gods || [])
+    const applyPosition = (x: number, y: number) => {
+      const el = rootRef.current
+      if (!el) return
+      el.style.left = `${x + 15}px`
+      el.style.top = `${y - 10}px`
+    }
 
-  const tooltipX = mousePosition.x + 15
-  const tooltipY = mousePosition.y - 10
+    useImperativeHandle(ref, () => ({
+      setPointer(x, y, nextIsOverCanvas) {
+        lastPointerRef.current = { x, y }
+        applyPosition(x, y)
+        if (overCanvasRef.current !== nextIsOverCanvas) {
+          overCanvasRef.current = nextIsOverCanvas
+          setIsOverCanvas(nextIsOverCanvas)
+        }
+      },
+    }))
 
-  const tooltipStyles = {
-    position: "fixed" as const,
-    left: tooltipX,
-    top: tooltipY,
-    background: "var(--gradient-tooltip)",
-    borderRadius: 12,
-    padding: "6px 10px",
-    backdropFilter: "blur(15px) saturate(180%)",
-    boxShadow:
-      "0 8px 32px rgba(0, 0, 0, 0.6), 0 4px 16px rgba(139, 101, 65, 0.2), 0 2px 8px rgba(212, 175, 55, 0.1), inset 0 1px 2px rgba(255, 255, 255, 0.1), inset 0 -1px 2px rgba(0, 0, 0, 0.3)",
-    zIndex: 1000,
-    maxWidth: 320,
-    minWidth: "auto",
-    opacity: 1,
-    transform: "translateY(0) scale(1)",
-    transition: "all 0.2s cubic-bezier(0.25, 0.8, 0.25, 1)",
-    pointerEvents: "none" as const,
-  }
+    useLayoutEffect(() => {
+      if (!hoveredSection) return
+      const { x, y } = lastPointerRef.current
+      applyPosition(x, y)
+    }, [hoveredSection])
 
-  return (
-    <Paper style={tooltipStyles} className="text-primary panel-border">
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            flexWrap: "wrap",
-          }}
-        >
-          <NumberBadge value={hoveredSection.id} size={28} />
+    if (
+      !hoveredSection ||
+      isMobile ||
+      isModifierKeyPressed ||
+      !isOverCanvas ||
+      isMouseOverPanel
+    ) {
+      return null
+    }
+
+    const deityNames = getGodsDisplayNames(hoveredSection.gods || [])
+
+    return (
+      <Paper
+        ref={rootRef}
+        style={{
+          position: "fixed",
+          left: 0,
+          top: 0,
+          background: "var(--gradient-tooltip)",
+          borderRadius: 12,
+          padding: "6px 10px",
+          backdropFilter: "blur(15px) saturate(180%)",
+          boxShadow:
+            "0 8px 32px rgba(0, 0, 0, 0.6), 0 4px 16px rgba(139, 101, 65, 0.2), 0 2px 8px rgba(212, 175, 55, 0.1), inset 0 1px 2px rgba(255, 255, 255, 0.1), inset 0 -1px 2px rgba(0, 0, 0, 0.3)",
+          zIndex: 1000,
+          maxWidth: 320,
+          minWidth: "auto",
+          opacity: 1,
+          transform: "translateY(0) scale(1)",
+          transition:
+            "opacity 0.2s cubic-bezier(0.25, 0.8, 0.25, 1), transform 0.2s cubic-bezier(0.25, 0.8, 0.25, 1)",
+          pointerEvents: "none",
+        }}
+        className="text-primary panel-border"
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div
-            className="text-primary"
             style={{
-              fontSize: "1em",
-              fontWeight: 600,
-              lineHeight: 1.2,
-              letterSpacing: "0.3px",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              flexWrap: "wrap",
             }}
           >
-            {deityNames}
+            <NumberBadge value={hoveredSection.id} size={28} />
+            <div
+              className="text-primary"
+              style={{
+                fontSize: "1em",
+                fontWeight: 600,
+                lineHeight: 1.2,
+                letterSpacing: "0.3px",
+              }}
+            >
+              {deityNames}
+            </div>
           </div>
+          <span
+            className="font-etruscan text-gradient-gold"
+            style={{
+              fontSize: "1.2em",
+              fontStyle: "italic",
+              letterSpacing: "0.5px",
+            }}
+          >
+            {hoveredSection.etruscanText}
+          </span>
         </div>
-        <span
-          className="font-etruscan text-gradient-gold"
-          style={{
-            fontSize: "1.2em",
-            fontStyle: "italic",
-            letterSpacing: "0.5px",
-          }}
-        >
-          {hoveredSection.etruscanText}
-        </span>
-      </div>
-    </Paper>
-  )
-}
+      </Paper>
+    )
+  },
+)

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,5 +7,5 @@
     "allowSyntheticDefaultImports": true,
     "strict": true
   },
-  "include": ["vite.config.js"]
+  "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,62 +1,90 @@
 import fs from "node:fs"
+import type { IncomingMessage, ServerResponse } from "node:http"
 import path from "node:path"
 import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { type Connect, defineConfig, type ViteDevServer } from "vite"
 import { VitePWA } from "vite-plugin-pwa"
 
 const LIVER_DATA_PATH = path.resolve("src/scene/LiverData.ts")
 
 const inscriptionPoseWriter = {
   name: "inscription-pose-writer",
-  apply: "serve",
-  configureServer(server) {
-    server.middlewares.use(async (req, res, next) => {
-      if (req.method !== "POST" || req.url !== "/__inscription_pose") {
-        return next()
-      }
-
-      try {
-        let body = ""
-        req.on("data", (chunk) => {
-          body += chunk
-        })
-        await new Promise<void>((resolve) => req.on("end", () => resolve()))
-        const parsed = JSON.parse(body || "{}")
-        const id = Number(parsed.id)
-        if (!Number.isFinite(id) || id <= 0) {
-          res.statusCode = 400
-          res.end("Invalid inscription id")
+  apply: "serve" as const,
+  configureServer(server: ViteDevServer) {
+    server.middlewares.use(
+      async (
+        req: IncomingMessage,
+        res: ServerResponse,
+        next: Connect.NextFunction,
+      ) => {
+        if (req.method !== "POST" || req.url !== "/__inscription_pose") {
+          return next()
+        }
+        if (process.env.VITE_ENABLE_POSE_WRITER !== "true") {
+          res.statusCode = 403
+          res.end("Pose writer is disabled")
           return
         }
-        const pos = parsed.cameraPosition || {}
-        const tgt = parsed.cameraTarget || {}
-        const formatNum = (n: number) =>
-          Number.isFinite(n) ? Number(n).toFixed(3) : "0"
-        const replacementPos = `new THREE.Vector3(${formatNum(pos.x)}, ${formatNum(pos.y)}, ${formatNum(pos.z)})`
-        const replacementTgt = `new THREE.Vector3(${formatNum(tgt.x)}, ${formatNum(tgt.y)}, ${formatNum(tgt.z)})`
-
-        const src = fs.readFileSync(LIVER_DATA_PATH, "utf8")
-        const regex = new RegExp(
-          `(id:\\s*${id}[\\s\\S]*?cameraPosition:\\s*)new THREE\\.Vector3\\([^)]+\\)([\\s\\S]*?cameraTarget:\\s*)new THREE\\.Vector3\\([^)]+\\)`,
-        )
-        if (!regex.test(src)) {
-          res.statusCode = 404
-          res.end(`Inscription ${id} not found in LiverData.ts`)
+        const address = req.socket.remoteAddress
+        if (address !== "::1" && address !== "127.0.0.1") {
+          res.statusCode = 403
+          res.end("Pose writer only accepts localhost requests")
           return
         }
-        const updated = src.replace(
-          regex,
-          `$1${replacementPos}$2${replacementTgt}`,
-        )
-        fs.writeFileSync(LIVER_DATA_PATH, updated, "utf8")
-        res.statusCode = 200
-        res.end("ok")
-      } catch (err) {
-        console.error("Failed to update LiverData.ts via dev API:", err)
-        res.statusCode = 500
-        res.end("Failed to update LiverData.ts")
-      }
-    })
+
+        try {
+          let body = ""
+          let bodyTooLarge = false
+          req.on("data", (chunk: Buffer) => {
+            if (body.length + chunk.length > 16 * 1024) {
+              bodyTooLarge = true
+              return
+            }
+            body += chunk.toString()
+          })
+          await new Promise<void>((resolve) => req.on("end", () => resolve()))
+          if (bodyTooLarge) {
+            res.statusCode = 413
+            res.end("Request body too large")
+            return
+          }
+          const parsed = JSON.parse(body || "{}")
+          const id = Number(parsed.id)
+          if (!Number.isFinite(id) || id <= 0) {
+            res.statusCode = 400
+            res.end("Invalid inscription id")
+            return
+          }
+          const pos = parsed.cameraPosition || {}
+          const tgt = parsed.cameraTarget || {}
+          const formatNum = (n: number) =>
+            Number.isFinite(n) ? Number(n).toFixed(3) : "0"
+          const replacementPos = `new THREE.Vector3(${formatNum(pos.x)}, ${formatNum(pos.y)}, ${formatNum(pos.z)})`
+          const replacementTgt = `new THREE.Vector3(${formatNum(tgt.x)}, ${formatNum(tgt.y)}, ${formatNum(tgt.z)})`
+
+          const src = fs.readFileSync(LIVER_DATA_PATH, "utf8")
+          const regex = new RegExp(
+            `(id:\\s*${id}[\\s\\S]*?cameraPosition:\\s*)new THREE\\.Vector3\\([^)]+\\)([\\s\\S]*?cameraTarget:\\s*)new THREE\\.Vector3\\([^)]+\\)`,
+          )
+          if (!regex.test(src)) {
+            res.statusCode = 404
+            res.end(`Inscription ${id} not found in LiverData.ts`)
+            return
+          }
+          const updated = src.replace(
+            regex,
+            `$1${replacementPos}$2${replacementTgt}`,
+          )
+          fs.writeFileSync(LIVER_DATA_PATH, updated, "utf8")
+          res.statusCode = 200
+          res.end("ok")
+        } catch (err) {
+          console.error("Failed to update LiverData.ts via dev API:", err)
+          res.statusCode = 500
+          res.end("Failed to update LiverData.ts")
+        }
+      },
+    )
   },
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,8 +25,12 @@ const inscriptionPoseWriter = {
           res.end("Pose writer is disabled")
           return
         }
-        const address = req.socket.remoteAddress
-        if (address !== "::1" && address !== "127.0.0.1") {
+        const address = req.socket.remoteAddress ?? ""
+        const isLocalhost =
+          address === "::1" ||
+          address === "127.0.0.1" ||
+          address === "::ffff:127.0.0.1"
+        if (!isLocalhost) {
           res.statusCode = 403
           res.end("Pose writer only accepts localhost requests")
           return
@@ -34,9 +38,11 @@ const inscriptionPoseWriter = {
 
         try {
           let body = ""
+          let bodyBytes = 0
           let bodyTooLarge = false
           req.on("data", (chunk: Buffer) => {
-            if (body.length + chunk.length > 16 * 1024) {
+            bodyBytes += chunk.length
+            if (bodyBytes > 16 * 1024) {
               bodyTooLarge = true
               return
             }


### PR DESCRIPTION
## Summary
- Disables OrbitControls damping so camera rotation stops immediately on mouse release.
- Stabilizes InteractionManager across remounts so inscription selection keeps working.
- Adds render invalidation for model rotation, hover/selection, and the intro pulse trail.
- Stops idle particle-driven GPU redraws once the scene is static.
- Caches segmentation mask IDs in a `Uint8Array` so hover picking avoids per-sample `getImageData`.
- Isolates hover-tooltip pointer updates onto a ref/DOM path so mousemove no longer re-renders the full scene UI tree.
- Cleans up WebGL/context/timer listeners, dead camera bookkeeping, and failed asset-load handling.
- Hardens the local pose-writer endpoint and gates debug globals to development.

## Performance impact
Engineering estimates from the changed code paths (not a before/after profiler capture):

- **~90–95% fewer idle scene draws** — particles no longer keep the GPU at ~30 FPS when the camera/model are still
- **~4× cheaper Shift / 3-finger model rotate** — AABB pivot and React notify once per gesture instead of every drag sample
- **Hover picking → O(1)** — downsampled mask IDs cached at load
- **Tooltip mousemove no longer re-renders the scene shell** — pointer position updates via ref/DOM
- **Peak interactive orbit FPS ≈ unchanged** — still bound by the liver mesh, shadows, and 4096² textures

Biggest real-world win is idle/mobile battery behavior, not a higher peak frame rate while spinning the camera.

## Test plan
- [ ] Drag to rotate the view and confirm it stops immediately on release
- [ ] Confirm Alt+drag pan, scroll zoom, and Shift/3-finger model rotation still work
- [ ] Confirm the intro color pulse runs through the cells (not stopping after a few)
- [ ] Click inscriptions to open the deity panel; hover highlights still appear
- [ ] Hover inscriptions on desktop and confirm the tooltip follows the cursor smoothly
- [ ] Confirm tooltip hides off-canvas / with Shift / over the panel; no tooltip on mobile
- [ ] Double-click / reset still restores the default view
- [ ] Leave the scene idle and confirm it is not continuously redrawing
- [ ] On phone: confirm hover/selection and idle behavior feel smoother / cooler