### PR TITLE
Isolate hover tooltip from scene re-renders

### DIFF
--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -30,7 +30,10 @@ import { About } from "./ui/components/About"
 import { ActionButtons } from "./ui/components/ActionButtons"
 import { ActionMenu } from "./ui/components/ActionMenu"
 import { BraveDisclaimer } from "./ui/components/BraveDisclaimer"
-import { HoverTooltip } from "./ui/components/HoverTooltip"
+import {
+  HoverTooltip,
+  type HoverTooltipHandle,
+} from "./ui/components/HoverTooltip"
 import { ResetInstruction } from "./ui/components/ResetInstruction"
 // UI Components
 import { DeityPanel } from "./ui/DeityPanel"
@@ -73,11 +76,6 @@ function PiacenzaLiverScene({
   const [isInteracting, setIsInteracting] = useState(false)
   const [isSceneReady, setIsSceneReady] = useState(false)
   const [isIntroTransitioning, setIsIntroTransitioning] = useState(false)
-  const [immediateMousePosition, setImmediateMousePosition] = useState({
-    x: 0,
-    y: 0,
-    isOverCanvas: true,
-  })
   const [isMouseOverPanel, setIsMouseOverPanel] = useState(false)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const [viewportKey, setViewportKey] = useState(0)
@@ -104,6 +102,7 @@ function PiacenzaLiverScene({
   const cameraControllerRef = useRef<CameraController | null>(null)
   const liverModelRef = useRef<LiverModel | null>(null)
   const interactionManagerRef = useRef<InteractionManager | null>(null)
+  const hoverTooltipRef = useRef<HoverTooltipHandle | null>(null)
 
   // Animation frame ref
   const animationIdRef = useRef<number | null>(null)
@@ -552,20 +551,11 @@ function PiacenzaLiverScene({
     setHasViewChanged(true)
   }, [hasInteracted, setHasInteracted, interactionMode])
 
-  // Mouse move handler with throttling to match raycast timing
-  const mouseMoveTimeoutRef = useRef<number | null>(null)
+  // Keep tooltip position on the DOM — avoid re-rendering the scene tree
+  // on every mousemove.
   const handleMouseMove = useCallback(
     (position: { x: number; y: number }, isOverCanvas: boolean) => {
-      // Clear existing timeout
-      if (mouseMoveTimeoutRef.current) {
-        clearTimeout(mouseMoveTimeoutRef.current)
-      }
-
-      // Throttle updates
-      mouseMoveTimeoutRef.current = window.setTimeout(() => {
-        setImmediateMousePosition({ ...position, isOverCanvas })
-        mouseMoveTimeoutRef.current = null
-      }, SceneConfig.performance.raycastThrottleMs)
+      hoverTooltipRef.current?.setPointer(position.x, position.y, isOverCanvas)
     },
     [],
   )
@@ -948,12 +938,6 @@ function PiacenzaLiverScene({
         introTimeoutRef.current = null
       }
 
-      // Clear mouse move timeout
-      if (mouseMoveTimeoutRef.current) {
-        clearTimeout(mouseMoveTimeoutRef.current)
-        mouseMoveTimeoutRef.current = null
-      }
-
       cameraController?.dispose()
       liverModelRef.current?.dispose()
       interactionManagerRef.current?.dispose()
@@ -1181,8 +1165,8 @@ function PiacenzaLiverScene({
         </section>
 
         <HoverTooltip
+          ref={hoverTooltipRef}
           hoveredSection={hoveredSection}
-          mousePosition={immediateMousePosition}
           isPanelOpen={isInscriptionMode}
           isModifierKeyPressed={isModifierKeyPressed}
           isMouseOverPanel={isMouseOverPanel}

--- a/src/ui/components/HoverTooltip.tsx
+++ b/src/ui/components/HoverTooltip.tsx
@@ -1,93 +1,131 @@
 import { Paper } from "@mantine/core"
+import {
+  forwardRef,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
 import { isMobile } from "react-device-detect"
 import { getGodsDisplayNames } from "../../scene/LiverData"
 import type { HoveredSection } from "../../types"
 import { NumberBadge } from "./NumberBadge"
 
+export type HoverTooltipHandle = {
+  setPointer: (x: number, y: number, isOverCanvas: boolean) => void
+}
+
 interface HoverTooltipProps {
   hoveredSection: HoveredSection | null
-  mousePosition: { x: number; y: number; isOverCanvas?: boolean }
   isPanelOpen?: boolean
   isModifierKeyPressed?: boolean
   isMouseOverPanel?: boolean
 }
 
-export function HoverTooltip({
-  hoveredSection,
-  mousePosition,
-  isModifierKeyPressed = false,
-  isMouseOverPanel = false,
-}: HoverTooltipProps) {
-  // Don't show tooltip if mobile, no hovered section, modifier keys are pressed, cursor is outside canvas, or cursor is over panel
-  if (
-    !hoveredSection ||
-    isMobile ||
-    isModifierKeyPressed ||
-    mousePosition.isOverCanvas === false ||
-    isMouseOverPanel
+export const HoverTooltip = forwardRef<HoverTooltipHandle, HoverTooltipProps>(
+  function HoverTooltip(
+    { hoveredSection, isModifierKeyPressed = false, isMouseOverPanel = false },
+    ref,
   ) {
-    return null
-  }
+    const rootRef = useRef<HTMLDivElement>(null)
+    const lastPointerRef = useRef({ x: 0, y: 0 })
+    const overCanvasRef = useRef(true)
+    const [isOverCanvas, setIsOverCanvas] = useState(true)
 
-  const deityNames = getGodsDisplayNames(hoveredSection.gods || [])
+    const applyPosition = (x: number, y: number) => {
+      const el = rootRef.current
+      if (!el) return
+      el.style.left = `${x + 15}px`
+      el.style.top = `${y - 10}px`
+    }
 
-  const tooltipX = mousePosition.x + 15
-  const tooltipY = mousePosition.y - 10
+    useImperativeHandle(ref, () => ({
+      setPointer(x, y, nextIsOverCanvas) {
+        lastPointerRef.current = { x, y }
+        applyPosition(x, y)
+        if (overCanvasRef.current !== nextIsOverCanvas) {
+          overCanvasRef.current = nextIsOverCanvas
+          setIsOverCanvas(nextIsOverCanvas)
+        }
+      },
+    }))
 
-  const tooltipStyles = {
-    position: "fixed" as const,
-    left: tooltipX,
-    top: tooltipY,
-    background: "var(--gradient-tooltip)",
-    borderRadius: 12,
-    padding: "6px 10px",
-    backdropFilter: "blur(15px) saturate(180%)",
-    boxShadow:
-      "0 8px 32px rgba(0, 0, 0, 0.6), 0 4px 16px rgba(139, 101, 65, 0.2), 0 2px 8px rgba(212, 175, 55, 0.1), inset 0 1px 2px rgba(255, 255, 255, 0.1), inset 0 -1px 2px rgba(0, 0, 0, 0.3)",
-    zIndex: 1000,
-    maxWidth: 320,
-    minWidth: "auto",
-    opacity: 1,
-    transform: "translateY(0) scale(1)",
-    transition: "all 0.2s cubic-bezier(0.25, 0.8, 0.25, 1)",
-    pointerEvents: "none" as const,
-  }
+    useLayoutEffect(() => {
+      if (!hoveredSection) return
+      const { x, y } = lastPointerRef.current
+      applyPosition(x, y)
+    }, [hoveredSection])
 
-  return (
-    <Paper style={tooltipStyles} className="text-primary panel-border">
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            flexWrap: "wrap",
-          }}
-        >
-          <NumberBadge value={hoveredSection.id} size={28} />
+    if (
+      !hoveredSection ||
+      isMobile ||
+      isModifierKeyPressed ||
+      !isOverCanvas ||
+      isMouseOverPanel
+    ) {
+      return null
+    }
+
+    const deityNames = getGodsDisplayNames(hoveredSection.gods || [])
+
+    return (
+      <Paper
+        ref={rootRef}
+        style={{
+          position: "fixed",
+          left: 0,
+          top: 0,
+          background: "var(--gradient-tooltip)",
+          borderRadius: 12,
+          padding: "6px 10px",
+          backdropFilter: "blur(15px) saturate(180%)",
+          boxShadow:
+            "0 8px 32px rgba(0, 0, 0, 0.6), 0 4px 16px rgba(139, 101, 65, 0.2), 0 2px 8px rgba(212, 175, 55, 0.1), inset 0 1px 2px rgba(255, 255, 255, 0.1), inset 0 -1px 2px rgba(0, 0, 0, 0.3)",
+          zIndex: 1000,
+          maxWidth: 320,
+          minWidth: "auto",
+          opacity: 1,
+          transform: "translateY(0) scale(1)",
+          transition:
+            "opacity 0.2s cubic-bezier(0.25, 0.8, 0.25, 1), transform 0.2s cubic-bezier(0.25, 0.8, 0.25, 1)",
+          pointerEvents: "none",
+        }}
+        className="text-primary panel-border"
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div
-            className="text-primary"
             style={{
-              fontSize: "1em",
-              fontWeight: 600,
-              lineHeight: 1.2,
-              letterSpacing: "0.3px",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              flexWrap: "wrap",
             }}
           >
-            {deityNames}
+            <NumberBadge value={hoveredSection.id} size={28} />
+            <div
+              className="text-primary"
+              style={{
+                fontSize: "1em",
+                fontWeight: 600,
+                lineHeight: 1.2,
+                letterSpacing: "0.3px",
+              }}
+            >
+              {deityNames}
+            </div>
           </div>
+          <span
+            className="font-etruscan text-gradient-gold"
+            style={{
+              fontSize: "1.2em",
+              fontStyle: "italic",
+              letterSpacing: "0.5px",
+            }}
+          >
+            {hoveredSection.etruscanText}
+          </span>
         </div>
-        <span
-          className="font-etruscan text-gradient-gold"
-          style={{
-            fontSize: "1.2em",
-            fontStyle: "italic",
-            letterSpacing: "0.5px",
-          }}
-        >
-          {hoveredSection.etruscanText}
-        </span>
-      </div>
-    </Paper>
-  )
-}
+      </Paper>
+    )
+  },
+)


### PR DESCRIPTION
## Summary
- Moves hover-tooltip pointer tracking off React state and onto a ref/DOM style path.
- Prevents mousemove from re-rendering the full scene UI tree (~InscriptionList, DeityPanel, overlays) on every cursor update.
- Keeps tooltip content re-renders only when the hovered inscription (or visibility flags) change.

## Test plan
- [ ] Hover inscriptions on desktop and confirm the tooltip follows the cursor smoothly
- [ ] Confirm tooltip hides when leaving the canvas, when Shift is held, and when the pointer is over the panel
- [ ] Confirm tooltip does not appear on mobile
- [ ] Confirm inscription click/selection and orbit controls still work
- [ ] Optional: React Profiler / why-did-you-render — scene shell should not update on pure mousemove