### PR TITLE
Extract Scene lighting and intro pose modules

### DIFF
--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -8,6 +8,7 @@ import * as THREE from "three"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
 // Core 3D logic
 import { CameraController } from "./camera/Controller"
+import { getIntroPose } from "./camera/introPose"
 import { SceneConfig } from "./config/SceneConfig"
 // Hooks
 import { useOrientation } from "./hooks/useOrientation"
@@ -24,6 +25,8 @@ import { InteractionManager } from "./scene/InteractionManager"
 // Data
 import { type Inscription, liverInscriptions } from "./scene/LiverData"
 import { LiverModel } from "./scene/LiverModel"
+import type { SceneProps } from "./scene/SceneProps"
+import { setupLighting } from "./scene/setupLighting"
 import type { HoveredSection } from "./types"
 import { InteractionMode } from "./types/interaction"
 import { About } from "./ui/components/About"
@@ -46,14 +49,7 @@ function PiacenzaLiverScene({
   hasInteracted,
   setHasInteracted,
   setTitleVisible,
-}: {
-  isLoading: boolean
-  setIsLoading: (loading: boolean) => void
-  setLoadingProgress: (progress: number) => void
-  hasInteracted: boolean
-  setHasInteracted: (interacted: boolean) => void
-  setTitleVisible: (visible: boolean) => void
-}) {
+}: SceneProps) {
   const navigate = useNavigate()
   const { i18n } = useTranslation("common")
   // Orientation detection
@@ -114,21 +110,6 @@ function PiacenzaLiverScene({
   const initialCameraDistanceRef = useRef<number | null>(null)
   const initialCameraTargetRef = useRef<THREE.Vector3 | null>(null)
   const hashNavigationTimeoutRef = useRef<number | null>(null)
-
-  const getIntroPose = useCallback(() => {
-    const aspect = window.innerWidth / window.innerHeight
-    const minAspect = 1
-    const maxAspect = 2.4
-    const clamped = Math.min(Math.max(aspect, minAspect), maxAspect)
-    const t = (clamped - minAspect) / (maxAspect - minAspect)
-    const targetX = 4 + t * 4
-    const position = SceneConfig.camera.lateral.clone()
-    position.x += t * 5
-    return {
-      position,
-      target: new THREE.Vector3(targetX, 0, 0),
-    }
-  }, [])
 
   // Particle animation refs
   const particleRefs = useRef<{
@@ -317,7 +298,7 @@ function PiacenzaLiverScene({
         }
       },
     )
-  }, [getIntroPose, setHasInteracted, setInteractionMode])
+  }, [setHasInteracted, setInteractionMode])
 
   const handleViewChange = useCallback(() => {
     if (interactionMode === InteractionMode.About) return
@@ -562,7 +543,6 @@ function PiacenzaLiverScene({
     isIntroTransitioning,
     isSceneReady,
     isPortrait,
-    getIntroPose,
     viewportKey,
   ])
 
@@ -1345,102 +1325,6 @@ function PiacenzaLiverScene({
   )
 }
 
-// Lighting setup function
-function setupLighting(scene: THREE.Scene) {
-  const config = SceneConfig.lighting
-
-  // Key light - spotlight for dramatic shadows on floor
-  const keyLight = new THREE.SpotLight(
-    config.lightColor,
-    config.keyLightIntensity * config.intensityMultiplier,
-  )
-  keyLight.position.set(0, 6, 3)
-  keyLight.target.position.set(0, 0, 0)
-  keyLight.angle = Math.PI / 6 // Narrower spotlight (30 degrees instead of 60)
-  keyLight.penumbra = 0.95
-  keyLight.decay = 2
-  keyLight.distance = 15
-  keyLight.castShadow = true
-  keyLight.shadow.mapSize.width = config.shadowMapSize
-  keyLight.shadow.mapSize.height = config.shadowMapSize
-  keyLight.shadow.camera.near = 0.1
-  keyLight.shadow.camera.far = 15
-  keyLight.shadow.camera.fov = 45
-  keyLight.shadow.bias = config.shadowBias
-  keyLight.shadow.normalBias = config.shadowNormalBias
-  keyLight.shadow.radius = config.shadowRadius
-  scene.add(keyLight)
-  scene.add(keyLight.target)
-
-  // Extremely subtle dust particles
-  const particleCount = 40
-  const particleGeometry = new THREE.BufferGeometry()
-  const positions = new Float32Array(particleCount * 3)
-  const velocities = new Float32Array(particleCount * 3)
-
-  for (let i = 0; i < particleCount; i++) {
-    const i3 = i * 3
-    const height = Math.random() * 6
-    const radius = (height / 6) * 1.8 * Math.random()
-    const angle = Math.random() * Math.PI * 2
-
-    positions[i3] = Math.cos(angle) * radius
-    positions[i3 + 1] = 6 - height
-    positions[i3 + 2] = Math.sin(angle) * radius + 1.5
-
-    velocities[i3] = (Math.random() - 0.5) * 0.0005
-    velocities[i3 + 1] = -Math.random() * 0.0003
-    velocities[i3 + 2] = (Math.random() - 0.5) * 0.0005
-  }
-
-  particleGeometry.setAttribute(
-    "position",
-    new THREE.BufferAttribute(positions, 3),
-  )
-  particleGeometry.setAttribute(
-    "velocity",
-    new THREE.BufferAttribute(velocities, 3),
-  )
-
-  const particleMaterial = new THREE.PointsMaterial({
-    color: config.lightColor,
-    size: 0.005,
-    transparent: true,
-    opacity: 0.12,
-    blending: THREE.AdditiveBlending,
-    depthWrite: false,
-  })
-
-  const particles = new THREE.Points(particleGeometry, particleMaterial)
-  scene.add(particles)
-
-  // Minimal ambient light for dramatic museum effect
-  const ambientLight = new THREE.AmbientLight(
-    config.ambientColor,
-    config.ambientIntensityMul * config.intensityMultiplier,
-  )
-  scene.add(ambientLight)
-
-  // Museum floor plane. The original was 5000×5000 — but the shadow camera
-  // only covers ~30 units of radius, the spot light range is 15 units, and
-  // the scene fog (0x000000 0.03) makes anything past ~50 units fade to black.
-  // 100×100 is more than enough and is visually identical, while saving the
-  // GPU from rasterizing a giant clipped polygon.
-  const floorGeometry = new THREE.PlaneGeometry(100, 100)
-  const floorMaterial = new THREE.MeshLambertMaterial({
-    color: 0x222222,
-    transparent: false,
-  })
-  const floor = new THREE.Mesh(floorGeometry, floorMaterial)
-  floor.rotation.x = -Math.PI / 2
-  floor.position.set(0, -3.0, 0)
-  floor.receiveShadow = true
-  // Floor is static — let the renderer skip its matrix update each frame.
-  floor.matrixAutoUpdate = false
-  floor.updateMatrix()
-  scene.add(floor)
-}
-
 export default function Scene({
   isLoading,
   setIsLoading,
@@ -1448,14 +1332,7 @@ export default function Scene({
   hasInteracted,
   setHasInteracted,
   setTitleVisible,
-}: {
-  isLoading: boolean
-  setIsLoading: (loading: boolean) => void
-  setLoadingProgress: (progress: number) => void
-  hasInteracted: boolean
-  setHasInteracted: (interacted: boolean) => void
-  setTitleVisible: (visible: boolean) => void
-}) {
+}: SceneProps) {
   return (
     <PiacenzaLiverScene
       isLoading={isLoading}

--- a/src/camera/introPose.ts
+++ b/src/camera/introPose.ts
@@ -1,0 +1,17 @@
+import * as THREE from "three"
+import { SceneConfig } from "../config/SceneConfig"
+
+export function getIntroPose() {
+  const aspect = window.innerWidth / window.innerHeight
+  const minAspect = 1
+  const maxAspect = 2.4
+  const clamped = Math.min(Math.max(aspect, minAspect), maxAspect)
+  const t = (clamped - minAspect) / (maxAspect - minAspect)
+  const targetX = 4 + t * 4
+  const position = SceneConfig.camera.lateral.clone()
+  position.x += t * 5
+  return {
+    position,
+    target: new THREE.Vector3(targetX, 0, 0),
+  }
+}

--- a/src/scene/SceneProps.ts
+++ b/src/scene/SceneProps.ts
@@ -1,0 +1,8 @@
+export type SceneProps = {
+  isLoading: boolean
+  setIsLoading: (loading: boolean) => void
+  setLoadingProgress: (progress: number) => void
+  hasInteracted: boolean
+  setHasInteracted: (interacted: boolean) => void
+  setTitleVisible: (visible: boolean) => void
+}

--- a/src/scene/setupLighting.ts
+++ b/src/scene/setupLighting.ts
@@ -1,0 +1,97 @@
+import * as THREE from "three"
+import { SceneConfig } from "../config/SceneConfig"
+
+export function setupLighting(scene: THREE.Scene) {
+  const config = SceneConfig.lighting
+
+  // Key light - spotlight for dramatic shadows on floor
+  const keyLight = new THREE.SpotLight(
+    config.lightColor,
+    config.keyLightIntensity * config.intensityMultiplier,
+  )
+  keyLight.position.set(0, 6, 3)
+  keyLight.target.position.set(0, 0, 0)
+  keyLight.angle = Math.PI / 6 // Narrower spotlight (30 degrees instead of 60)
+  keyLight.penumbra = 0.95
+  keyLight.decay = 2
+  keyLight.distance = 15
+  keyLight.castShadow = true
+  keyLight.shadow.mapSize.width = config.shadowMapSize
+  keyLight.shadow.mapSize.height = config.shadowMapSize
+  keyLight.shadow.camera.near = 0.1
+  keyLight.shadow.camera.far = 15
+  keyLight.shadow.camera.fov = 45
+  keyLight.shadow.bias = config.shadowBias
+  keyLight.shadow.normalBias = config.shadowNormalBias
+  keyLight.shadow.radius = config.shadowRadius
+  scene.add(keyLight)
+  scene.add(keyLight.target)
+
+  // Extremely subtle dust particles
+  const particleCount = 40
+  const particleGeometry = new THREE.BufferGeometry()
+  const positions = new Float32Array(particleCount * 3)
+  const velocities = new Float32Array(particleCount * 3)
+
+  for (let i = 0; i < particleCount; i++) {
+    const i3 = i * 3
+    const height = Math.random() * 6
+    const radius = (height / 6) * 1.8 * Math.random()
+    const angle = Math.random() * Math.PI * 2
+
+    positions[i3] = Math.cos(angle) * radius
+    positions[i3 + 1] = 6 - height
+    positions[i3 + 2] = Math.sin(angle) * radius + 1.5
+
+    velocities[i3] = (Math.random() - 0.5) * 0.0005
+    velocities[i3 + 1] = -Math.random() * 0.0003
+    velocities[i3 + 2] = (Math.random() - 0.5) * 0.0005
+  }
+
+  particleGeometry.setAttribute(
+    "position",
+    new THREE.BufferAttribute(positions, 3),
+  )
+  particleGeometry.setAttribute(
+    "velocity",
+    new THREE.BufferAttribute(velocities, 3),
+  )
+
+  const particleMaterial = new THREE.PointsMaterial({
+    color: config.lightColor,
+    size: 0.005,
+    transparent: true,
+    opacity: 0.12,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+  })
+
+  const particles = new THREE.Points(particleGeometry, particleMaterial)
+  scene.add(particles)
+
+  // Minimal ambient light for dramatic museum effect
+  const ambientLight = new THREE.AmbientLight(
+    config.ambientColor,
+    config.ambientIntensityMul * config.intensityMultiplier,
+  )
+  scene.add(ambientLight)
+
+  // Museum floor plane. The original was 5000×5000 — but the shadow camera
+  // only covers ~30 units of radius, the spot light range is 15 units, and
+  // the scene fog (0x000000 0.03) makes anything past ~50 units fade to black.
+  // 100×100 is more than enough and is visually identical, while saving the
+  // GPU from rasterizing a giant clipped polygon.
+  const floorGeometry = new THREE.PlaneGeometry(100, 100)
+  const floorMaterial = new THREE.MeshLambertMaterial({
+    color: 0x222222,
+    transparent: false,
+  })
+  const floor = new THREE.Mesh(floorGeometry, floorMaterial)
+  floor.rotation.x = -Math.PI / 2
+  floor.position.set(0, -3.0, 0)
+  floor.receiveShadow = true
+  // Floor is static — let the renderer skip its matrix update each frame.
+  floor.matrixAutoUpdate = false
+  floor.updateMatrix()
+  scene.add(floor)
+}


### PR DESCRIPTION
## Summary
- Moves `setupLighting` into `src/scene/setupLighting.ts`.
- Moves intro-camera pose math into `src/camera/introPose.ts`.
- Shares `SceneProps` between the scene wrapper and inner component.
- No intentional behavior changes.

## Test plan
- [ ] Scene loads with lighting, floor, and dust particles
- [ ] About/intro camera pose still looks correct on resize
- [ ] Inscription focus / reset / panel close camera moves still work