### PR TITLE
Use unlit materials for inscription highlight overlays

### DIFF
--- a/src/scene/LiverModel.ts
+++ b/src/scene/LiverModel.ts
@@ -50,9 +50,9 @@ export class LiverModel {
 
   private onModelReady?: () => void
   private atlasTexture: THREE.Texture | null = null
-  private selectedMaterial: THREE.MeshStandardMaterial | null = null
+  private selectedMaterial: THREE.MeshBasicMaterial | null = null
   private selectedMesh: THREE.Mesh | null = null
-  private hoveredMaterial: THREE.MeshStandardMaterial | null = null
+  private hoveredMaterial: THREE.MeshBasicMaterial | null = null
   private hoveredMesh: THREE.Mesh | null = null
   private atlasCols = 1
   private atlasRows = 1
@@ -375,8 +375,10 @@ export class LiverModel {
       baseMaterial.shadowSide = THREE.FrontSide
 
       // Create separate materials for selected and hovered states
+      // Unlit overlay materials — color + alphaMap only; no PBR lighting cost
+      // on the extra 44k-tri hover/selection passes.
       const createHighlightMaterial = () =>
-        new THREE.MeshStandardMaterial({
+        new THREE.MeshBasicMaterial({
           color: new THREE.Color(0xffc107),
           transparent: true,
           opacity: 0.0,
@@ -540,7 +542,7 @@ export class LiverModel {
   }
 
   private updateHighlight(
-    material: THREE.MeshStandardMaterial | null,
+    material: THREE.MeshBasicMaterial | null,
     overlayMesh: THREE.Mesh | null,
     inscriptionId: number,
     opacity: number,
@@ -608,7 +610,7 @@ export class LiverModel {
 
   private applyHighlightToMaterial(
     inscriptionId: number,
-    material: THREE.MeshStandardMaterial,
+    material: THREE.MeshBasicMaterial,
     opacity: number,
   ) {
     // Remap incoming id if configured


### PR DESCRIPTION
## Summary
- Switches hover/selection overlay materials from `MeshStandardMaterial` to `MeshBasicMaterial`.
- Overlays are additive color+alphaMap decals and do not need PBR lighting, so this cuts fragment cost on the extra full-mesh passes.
- Based on `#7` so intro-pulse render invalidation stays in place (avoids the earlier “pulse stops early” regression).

## Test plan
- [ ] Intro color pulse runs through all cells
- [ ] Hover highlight appears and tracks inscriptions
- [ ] Selection highlight appears when opening a cell
- [ ] Hover+selection together look correct (no overlap glitch on selected cell)
- [ ] Shift/3-finger rotate still requests redraws with highlights visible